### PR TITLE
Wrong results in `as_database_key` for negative positions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,21 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1.0"
-sqlx = { version = "0.7", features = [ "runtime-async-std" ], optional = true }
-redis = { version = "0.23", default-features = false, features = [ "async-std-comp" ], optional = true }
+sqlx = { version = "0.7", features = ["runtime-async-std"], optional = true }
+redis = { version = "0.23", default-features = false, features = [
+    "async-std-comp",
+], optional = true }
 leveldb-rs = { version = "0.0.7", optional = true }
 url = { version = "2.2", optional = true }
-async-std = { version = "1", features = [ "attributes" ] }
+async-std = { version = "1", features = ["attributes"] }
 futures = "0.3"
-zstd = "0.12"
+zstd = "0.13"
 log = "0.4"
 num-integer = "0.1" # Needed for div_floor until https://github.com/rust-lang/rust/issues/88581 is stabilized
+glam = { git = "https://github.com/bitshifter/glam-rs.git" }
 
 [target.'cfg(not(all(target_endian = "big", target_pointer_width = "32")))'.dependencies]
-smartstring = {version = "1", optional = true}
+smartstring = { version = "1", optional = true }
 
 [features]
 default = ["redis", "sqlite", "postgres"]

--- a/examples/create_world.rs
+++ b/examples/create_world.rs
@@ -7,7 +7,7 @@ async fn main() {
     for y in -99..100 {
         for x in -100..100 {
             for z in -100..100 {
-                let pos = Position { x, y, z };
+                let pos = Position::new::<i16>(x, y, z);
                 let content: &[u8] = if y > 0 { b"air" } else { b"default:wood" };
                 vm.set_node(
                     pos,

--- a/examples/modify_map.rs
+++ b/examples/modify_map.rs
@@ -5,7 +5,7 @@ async fn main() {
     let world = World::open("TestWorld");
     let mut vm = world.get_voxel_manip(true).await.unwrap();
     for y in 10..20 {
-        vm.set_content(Position { x: 0, y, z: 0 }, b"default:diamondblock")
+        vm.set_content(Position::new::<i16>(0, y, 0), b"default:diamondblock")
             .await
             .unwrap();
     }

--- a/examples/modify_mapblocks.rs
+++ b/examples/modify_mapblocks.rs
@@ -17,7 +17,7 @@ async fn main() {
         let mut block = data.get_mapblock(pos).await.unwrap();
         for x in 0..8 {
             let content_id = block.get_or_create_content_id(b"default:apple");
-            block.set_content(Position { x, y: 0, z: 0 }, content_id);
+            block.set_content(Position::new::<i16>(x, 0, 0), content_id);
         }
         data.set_mapblock(pos, &block).await.unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,7 @@
 //! use minetestworld::{World, Position};
 //! use async_std::task;
 //!
-//! let blockpos = Position {
-//!     x: -13,
-//!     y: -8,
-//!     z: 2,
-//! };
+//! let blockpos = Position::new::<i16>(-13, -8, 2);
 //!
 //! task::block_on(async {
 //!     let world = World::open("TestWorld");

--- a/src/map_data.rs
+++ b/src/map_data.rs
@@ -238,9 +238,9 @@ impl MapData {
                 .map_err(|e| MapDataError::from_sqlx_error(e, pos)),
             #[cfg(feature = "postgres")]
             MapData::Postgres(pool) => sqlx::query(POSTGRES_QUERY)
-                .bind(pos.x)
-                .bind(pos.y)
-                .bind(pos.z)
+                .bind(pos.0.x)
+                .bind(pos.0.y)
+                .bind(pos.0.z)
                 .fetch_one(pool)
                 .await
                 .and_then(|row| row.try_get("data"))
@@ -283,9 +283,9 @@ impl MapData {
                 .map_err(MapDataError::SqlError),
             #[cfg(feature = "postgres")]
             MapData::Postgres(pool) => sqlx::query(POSTGRES_UPSERT)
-                .bind(pos.x)
-                .bind(pos.y)
-                .bind(pos.z)
+                .bind(pos.0.x)
+                .bind(pos.0.y)
+                .bind(pos.0.z)
                 .bind(data)
                 .execute(pool)
                 .await

--- a/src/positions.rs
+++ b/src/positions.rs
@@ -2,9 +2,9 @@
 
 use crate::MAPBLOCK_LENGTH;
 use num_integer::div_floor;
-#[cfg(any(feature = "postgres"))]
+#[cfg(feature = "postgres")]
 use sqlx::postgres::PgRow;
-#[cfg(any(feature = "sqlite"))]
+#[cfg(feature = "sqlite")]
 use sqlx::sqlite::SqliteRow;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 use sqlx::{FromRow, Row};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -72,12 +72,8 @@ async fn can_parse_all_mapblocks() {
         .try_collect()
         .await
         .unwrap();
-    let blocks: Vec<_> = futures::future::join_all(
-        positions
-            .iter()
-            .map(|pos| mapdata.get_mapblock(pos.clone())),
-    )
-    .await;
+    let blocks: Vec<_> =
+        futures::future::join_all(positions.iter().map(|pos| mapdata.get_mapblock(*pos))).await;
     let succeeded = blocks.iter().filter(|b| b.is_ok()).count();
     let failed = blocks.iter().filter(|b| b.is_err()).count();
     eprintln!("Succeeded parsed blocks: {succeeded}\nFailed blocks: {failed}");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,11 +10,11 @@ use futures::prelude::*;
 fn simple_math() {
     assert_eq!(
         Position::from_database_key(134270984),
-        Position { x: 8, y: 13, z: 8 }
+        Position::new::<i16>(8, 13, 8)
     );
     assert_eq!(
         Position::from_database_key(-184549374),
-        Position { x: 2, y: 0, z: -11 }
+        Position::new::<i16>(2, 0, -11)
     );
 }
 
@@ -32,11 +32,7 @@ async fn can_query() {
         .unwrap();
     assert_eq!(mapdata.all_mapblock_positions().await.count().await, 5923);
     let block = mapdata
-        .get_block_data(Position {
-            x: -13,
-            y: -8,
-            z: 2,
-        })
+        .get_block_data(Position::new::<i16>(-13, -8, 2))
         .await
         .unwrap();
     assert_eq!(block.len(), 40);
@@ -44,7 +40,7 @@ async fn can_query() {
 
 #[async_std::test]
 async fn mapblock_miss() {
-    let position = Position { x: 0, y: 0, z: 0 };
+    let position = Position::new::<i16>(0, 0, 0);
     let mapdata = MapData::from_sqlite_file("TestWorld/map.sqlite", true)
         .await
         .unwrap();
@@ -86,11 +82,7 @@ async fn count_nodes() {
         .await
         .unwrap();
     let count = mapdata
-        .iter_mapblock_nodes(Position {
-            x: -13,
-            y: -8,
-            z: 2,
-        })
+        .iter_mapblock_nodes(Position::new::<i16>(-13, -8, 2))
         .await
         .unwrap()
         .count();
@@ -99,11 +91,7 @@ async fn count_nodes() {
 
 #[async_std::test]
 async fn iter_node_positions() {
-    let blockpos = Position {
-        x: -13,
-        y: -8,
-        z: 2,
-    };
+    let blockpos = Position::new::<i16>(-13, -8, 2);
 
     let world = World::open("TestWorld");
     let mapdata = world.get_map_data().await.unwrap();
@@ -114,14 +102,10 @@ async fn iter_node_positions() {
 
 #[test]
 fn node_index() {
-    assert_eq!(Position::from_node_index(0), Position { x: 0, y: 0, z: 0 });
+    assert_eq!(Position::from_node_index(0), Position::new::<i16>(0, 0, 0));
     assert_eq!(
         Position::from_node_index(4095),
-        Position {
-            x: 15,
-            y: 15,
-            z: 15,
-        }
+        Position::new::<i16>(15, 15, 15)
     )
 }
 

--- a/src/voxel_manip.rs
+++ b/src/voxel_manip.rs
@@ -73,7 +73,7 @@ impl VoxelManip {
         blockpos: Position,
         op: impl FnOnce(&mut MapBlock),
     ) -> Result<()> {
-        let mut entry = &mut self.get_entry(blockpos).await?;
+        let entry = &mut self.get_entry(blockpos).await?;
         op(&mut entry.mapblock);
         entry.tainted = true;
         Ok(())


### PR DESCRIPTION
Thanks a lot for your crate! I'd like to base a map generator on it. I forked your project to see whether I could improve performance and ergonomics for my specific use-cases and found an error in `as_database_key`. Negative position will result in wrong keys and vice versa.

This test _should_ have covered this but somehow it's using a negative database key which I think is not correct.
```
    assert_eq!(
        Position::from_database_key(-184549374),
        Position::new::<i16>(2, 0, -11)
    );
```

Are you sure database keys can be negative at all? That would at least be uncommon.

This PR is not meant to be merged, but to show you how I fixed it in my local sandbox (did not change the test, yet). I did some random round-trip conversions (`from_database_key`, `as_database_key`) and it looks fine to me.

Feel free to cherry-pick whatever you need :)

(BTW I just added `I16Vec` to glam, to be able to use it for minetest map generations - not publicly released, yet)