### PR TITLE
Changes to make speedups possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,12 @@ extern crate smartstring;
 pub mod map_block;
 pub mod map_data;
 pub mod positions;
+pub mod reexport;
 pub mod voxel_manip;
 pub mod world;
 
 pub use map_block::MapBlock;
-pub use map_block::Node;
+pub use map_block::{IdName, Node};
 pub use map_data::MapData;
 pub use map_data::MapDataError;
 pub use positions::Position;

--- a/src/map_block.rs
+++ b/src/map_block.rs
@@ -108,6 +108,10 @@ impl<'a> NodeId<'a> {
     fn new(id: u16) -> Self {
         Self(id, PhantomData::default())
     }
+    /// Returns the raw numerical value
+    pub fn raw_id(&self) -> u16 {
+        self.0
+    }
 }
 
 /// The physical composition of the world at a specific voxel
@@ -150,7 +154,7 @@ pub enum MapBlockError {
 }
 
 /// Maps mapblock-local content IDs to content types
-pub type NameIdMappings = HashMap<u16, Vec<u8>>;
+pub type NameIdMappings = HashMap<u16, IdName>;
 
 /// A single node metadata variable, consisting of a key and a value
 #[derive(Debug)]
@@ -353,7 +357,17 @@ impl MapBlock {
     }
 
     /// Queries the mapblock for a node on the given mapblock-relative coordinates
-    pub fn get_node_at(&self, relative_node_pos: Position) -> Node<IdName> {
+    pub fn get_node_at(&self, relative_node_pos: Position) -> Node<NodeId<'_>> {
+        let index = relative_node_pos.as_node_index() as usize % MAPBLOCK_SIZE;
+        Node {
+            param0: NodeId::new(self.param0[index]),
+            param1: self.param1[index],
+            param2: self.param2[index],
+        }
+    }
+    
+    /// Queries the mapblock for a node on the given mapblock-relative coordinates
+    pub fn get_owned_node(&self, relative_node_pos: Position) -> Node<IdName> {
         let index = relative_node_pos.as_node_index() as usize % MAPBLOCK_SIZE;
         let param0 = self.content_from_id(self.param0[index]);
         Node {

--- a/src/map_block.rs
+++ b/src/map_block.rs
@@ -34,6 +34,8 @@ pub type IdName = Vec<u8>;
 /// assert_eq!(MAPBLOCK_LENGTH, 16);
 /// ```
 pub const MAPBLOCK_LENGTH: u8 = 16;
+/// Bit shift to convert indices
+pub const MAPBLOCK_SHIFT: u8 = 4;
 
 /// How many nodes are contained in a map block.
 ///
@@ -157,7 +159,7 @@ pub enum MapBlockError {
 pub type NameIdMappings = HashMap<u16, IdName>;
 
 /// A single node metadata variable, consisting of a key and a value
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeVar {
     /// The 'name' of this variable
     pub key: Vec<u8>,
@@ -170,7 +172,7 @@ pub struct NodeVar {
 /// Metadata of a node
 ///
 /// In game, this is used for e.g. the inventory of a chest or the text of a sign
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeMetadata {
     /// The mapblock-relative node position of this item
     pub position: Position,
@@ -183,7 +185,7 @@ pub struct NodeMetadata {
 /// Objects in the world that are not nodes
 ///
 /// For example a LuaEntity
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StaticObject {
     /// Type ID
     pub type_id: u8,
@@ -198,7 +200,7 @@ pub struct StaticObject {
 }
 
 /// Represents a running node timer
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeTimer {
     /// The mapblock-relative node position of this timer
     pub position: Position,
@@ -211,7 +213,7 @@ pub struct NodeTimer {
 /// A 'chunk' of voxels; the data unit saved in a backend
 ///
 /// Refer to <https://github.com/minetest/minetest/blob/master/doc/world_format.md>
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MapBlock {
     /// The format version of the mapblock. Currently supported is only version 29.
     ///

--- a/src/map_data.rs
+++ b/src/map_data.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 #[cfg(feature = "redis")]
 use url::Host;
 
-use crate::map_block::{MapBlock, MapBlockError, Node, NodeIter};
+use crate::map_block::{MapBlock, MapBlockError};
 use crate::positions::Position;
 
 const POSTGRES_QUERY: &str = "SELECT data FROM blocks
@@ -303,16 +303,5 @@ impl MapData {
     /// Inserts or replaces the map block at `pos`
     pub async fn set_mapblock(&self, pos: Position, block: &MapBlock) -> Result<(), MapDataError> {
         self.set_mapblock_data(pos, &block.to_binary()?).await
-    }
-
-    /// Enumerate all nodes from the mapblock at `pos`
-    ///
-    /// Yields all nodes along with their relative position within the map block
-    pub async fn iter_mapblock_nodes(
-        &self,
-        mapblock_pos: Position,
-    ) -> Result<impl Iterator<Item = (Position, Node)>, MapDataError> {
-        let mapblock = self.get_mapblock(mapblock_pos).await?;
-        Ok(NodeIter::from(mapblock, mapblock_pos))
     }
 }

--- a/src/positions.rs
+++ b/src/positions.rs
@@ -154,7 +154,7 @@ impl Position {
     }
 
     /// Convert a MapBlock-relative node position into a flat array index
-    pub(crate) fn as_node_index(&self) -> u16 {
+    pub fn as_node_index(&self) -> u16 {
         self.x as u16 + 16 * self.y as u16 + 256 * self.z as u16
     }
 

--- a/src/reexport.rs
+++ b/src/reexport.rs
@@ -1,0 +1,1 @@
+pub use futures::stream;

--- a/src/voxel_manip.rs
+++ b/src/voxel_manip.rs
@@ -3,7 +3,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use crate::{MapBlock, MapData, MapDataError, Node, Position};
+use crate::{MapBlock, MapData, MapDataError, Node, Position, IdName};
 type Result<T> = std::result::Result<T, MapDataError>;
 
 struct CacheEntry {
@@ -62,7 +62,7 @@ impl VoxelManip {
     }
 
     /// Get the node at the given world position
-    pub async fn get_node(&mut self, node_pos: Position) -> Result<Node> {
+    pub async fn get_node(&mut self, node_pos: Position) -> Result<Node<IdName>> {
         let (blockpos, nodepos) = node_pos.split_at_block();
         Ok(self.get_mapblock(blockpos).await?.get_node_at(nodepos))
     }
@@ -83,7 +83,7 @@ impl VoxelManip {
     ///
     /// ⚠️ The change will be present locally only. To modify the map,
     /// the change has to be written back via [`VoxelManip::commit`].
-    pub async fn set_node(&mut self, node_pos: Position, node: Node) -> Result<()> {
+    pub async fn set_node(&mut self, node_pos: Position, node: Node<IdName>) -> Result<()> {
         let (blockpos, nodepos) = node_pos.split_at_block();
         self.modify_mapblock(blockpos, |mapblock| {
             let content_id = mapblock.get_or_create_content_id(&node.param0);

--- a/src/voxel_manip.rs
+++ b/src/voxel_manip.rs
@@ -64,7 +64,7 @@ impl VoxelManip {
     /// Get the node at the given world position
     pub async fn get_node(&mut self, node_pos: Position) -> Result<Node<IdName>> {
         let (blockpos, nodepos) = node_pos.split_at_block();
-        Ok(self.get_mapblock(blockpos).await?.get_node_at(nodepos))
+        Ok(self.get_mapblock(blockpos).await?.get_owned_node(nodepos))
     }
 
     /// Do something with the mapblock at `blockpos` and mark it as modified


### PR DESCRIPTION
Here's a bunch of changes that I needed to make to speed up access to nodes - especially now the ID is exposed directly.
It makes mistakes possible, but the upside is that the code can work more than twice as fast.